### PR TITLE
add missing "require" for url dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var url = require('url');
+
 module.exports = function(nforce, pluginName) {
 
   // plugin definition


### PR DESCRIPTION
Just a minor change - pretty self explanatory. Just adding the missing `var url = require('url')` dependency otherwise the plugin throws a `ReferenceError` when parsing the `redirectUri`.
